### PR TITLE
new params

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,7 @@ To log to the console instead of rsyslog, call
 `bootstrap(rsyslog=False, console=True, circus=False)`; it will also prevent spawning of rsyslogd and circus.
 
 Usually `bootstrap()` should be called by the testcase setup logic.
+
+Optionally pass the path to Rsyslogd config and PID files (rsyslogd_config_path and rsyslogd_pid_path): this help avoiding conflicts with the rsyslogd service running on the host machine.
+
+Caveat: if rsyslogd is configured to rotate logs it is adviced to use version >= 8 from the rsyslogd repository (http://www.rsyslog.com/ubuntu-repository) or unexpected behaviour may occur.

--- a/docker_bootstrap/base.py
+++ b/docker_bootstrap/base.py
@@ -70,8 +70,11 @@ def setup_logging(log_level=None, log_console=None, log_rsyslog=None):
 
 
 def setup_rsyslog_logging(log_level=None, logentries_token=None,
-                          rsyslog_debug=None):
+                          rsyslog_debug=None, rsyslog_config_path=None,
+                          rsyslog_pid_path=None):
     '''Configures and spawns rsyslog. '''
+    _rsyslog_config_path = rsyslog_config_path or RSYSLOG_CONFIG_PATH
+    _rsyslog_pid_path = rsyslog_pid_path or RSYSLOG_PID_PATH
     env = Environment(loader=FileSystemLoader(TEMPLATE_DIR))
     template = env.get_template('rsyslog.conf.jinja2')
     contents = template.render(
@@ -81,12 +84,12 @@ def setup_rsyslog_logging(log_level=None, logentries_token=None,
                        else os.environ.get('RSYSLOG_DEBUG', False))
     )
 
-    with open(RSYSLOG_CONFIG_PATH, 'w') as f:
+    with open(_rsyslog_config_path, 'w') as f:
         f.write(contents)
 
     # spawn rsyslog
-    rsyslog = subprocess.Popen(['rsyslogd', '-i', RSYSLOG_PID_PATH,
-                                '-f', RSYSLOG_CONFIG_PATH],
+    rsyslog = subprocess.Popen(['rsyslogd', '-i', _rsyslog_pid_path,
+                                '-f', _rsyslog_config_path],
                                stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)
     print('Spawning rsyslog...')


### PR DESCRIPTION
There is a small ambiguity when running rsyslod inside the Docker container when it is also running on the hosting server:

```
$ ps waux | grep rsyslo
...
root      4213  0.0  0.0 259984   388 ?        Ssl  Mar03   2:14 rsyslogd -i /rsyslog.pid -f /rsyslog.conf
root     18099  0.0  0.0 259984   204 ?        Ssl  Mar05   0:42 rsyslogd -i /rsyslog.pid -f /rsyslog.conf
```

A sysadmin can unknowingly kill one.

We could specify the PID and the config file of the rsyslogd running inside the chrooted environment with a explicit name, such as `rsyslogd-docker.conf` and `rsyslogd-docker.pid`.

I don't know if this solves also possibly solves clashes and resource contention with the PID file (theoretically no, being the container chrooted).

Also, we discovered that logrotating kind of requires rsyslod +v8
